### PR TITLE
Incorrect volume mount name and missing version in example

### DIFF
--- a/app/rest/main.go
+++ b/app/rest/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	status, body, err := rproxy.Send("GET", "api/v3/pools", nil, rest.GetPoolsRCode)
 
-	var gprsp = &rest.GetPoolsData{}
+	gprsp := &rest.GetPoolsData{}
 	if err := json.Unmarshal(body, &gprsp); err != nil {
 		panic(err)
 	}

--- a/deploy/cfg/controller.yaml
+++ b/deploy/cfg/controller.yaml
@@ -4,6 +4,8 @@ plugins :
     - CONTROLLER_SERVICE # init controller service
     - IDENTITY_SERVICE
 
+version: alpha
+
 controller :
     id: node-1
     salt: some-salt

--- a/deploy/joviandss/joviandss-csi-controller.yaml
+++ b/deploy/joviandss/joviandss-csi-controller.yaml
@@ -128,7 +128,7 @@ spec:
             - --config=$(JOVIANDSS_CONFIG)
           env:
             - name: JOVIANDSS_CONFIG
-              value: /config/controller-cfg.yaml
+              value: /config/controller.yaml
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true

--- a/deploy/joviandss/joviandss-csi-node.yaml
+++ b/deploy/joviandss/joviandss-csi-node.yaml
@@ -79,7 +79,7 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --soc-type=unix
-            - --config=/config/node-cfg.yaml
+            - --config=/config/node.yaml
             - --nodeid=$(KUBE_NODE_NAME)
           env:
             - name: KUBE_NODE_NAME

--- a/pkg/joviandss/nodeplugin.go
+++ b/pkg/joviandss/nodeplugin.go
@@ -216,6 +216,7 @@ func (ns *NodePlugin) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 
 }
 
+// NodeGetVolumeStats volume total and available space
 func (np *NodePlugin) NodeGetVolumeStats(ctx context.Context, in *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
 }

--- a/pkg/joviandss/targetapi.go
+++ b/pkg/joviandss/targetapi.go
@@ -305,25 +305,22 @@ func (t *Target) SetChapCred() error {
 	exec := mount.NewOSExec()
 	tname := t.Iqn + ":" + t.Tname
 
-	t.l.Tracef("Target: %s", t.Tname)
+	t.l.Tracef("Target: %s", tname)
 
-	out, err := exec.Run("iscsiadm", "-m", "node", "-p", t.Portal,
-		"-T", tname, "-o", "update",
-		"-n", "node.session.auth.authmethod", "-v", "CHAP")
+	out, err := exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "-o", "update", "-n",
+		"node.session.auth.authmethod", "-v", "CHAP")
 	if err != nil {
 		t.l.Errorf("Could not update authentication method for %s error: %s", tname, string(out))
 		return err
 	}
 
-	out, err = exec.Run("iscsiadm", "-m", "node", "-p", t.Portal,
-		"-T", tname, "-o", "update",
-		"-n", "node.session.auth.username", "-v", t.CoUser)
+	out, err = exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "-o", "update", "-n",
+		"node.session.auth.username", "-v", t.CoUser)
 	if err != nil {
 		return fmt.Errorf("iscsi: failed to update node session user error: %v", string(out))
 	}
-	out, err = exec.Run("iscsiadm", "-m", "node", "-p", t.Portal,
-		"-T", tname, "-o", "update",
-		"-n", "node.session.auth.password", "-v", t.CoPass)
+	out, err = exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "-o", "update", "-n",
+		"node.session.auth.password", "-v", t.CoPass)
 	if err != nil {
 		return fmt.Errorf("iscsi: failed to update node session password error: %v", string(out))
 	}
@@ -444,22 +441,22 @@ func (t *Target) StageVolume() error {
 
 	devicePath := strings.Join([]string{deviceIPPath, fullPortal, "iscsi", tname, "lun", t.Lun}, "-")
 
-	exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", t.Portal, "-o", "new")
-
-	exec.Run("iscsiadm", "-m", "discoverydb", "-t", "sendtargets", "-p", t.Portal, "--discover")
-
-	exec.Run("iscsiadm", "-m", "discovery", "-t", "sendtargets", "-p", t.Portal)
+	out, err := exec.Run("iscsiadm", "-m", "node", "-T", tname, "-p", t.Portal, "-o", "new")
+	if err != nil {
+		msg := fmt.Sprintf("Unable to add targetation %s error: %s", tname, err.Error())
+		return errors.New(msg)
+	}
 
 	// Set properties
 
-	err := t.SetChapCred()
+	err = t.SetChapCred()
 	if err != nil {
 		msg := fmt.Sprintf("iscsi: failed to update iscsi node to portal %s error: %v", tname, err)
 		return errors.New(msg)
 	}
 
 	//Attach Target
-	out, err := exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "--login")
+	out, err = exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "--login")
 	if err != nil {
 		t.ClearChapCred()
 		exec.Run("iscsiadm", "-m", "node", "-p", t.Portal, "-T", tname, "-o", "delete")

--- a/pkg/rest/errors.go
+++ b/pkg/rest/errors.go
@@ -27,7 +27,7 @@ const (
 	RestRequestMalfunction    = 3
 	RestResourceDNE           = 4
 	RestUnableToConnect       = 5
-	RestRPM                   = 6 // Response Processing malfunction
+	RestRPM                   = 6 // Response Processing Malfunction
 	RestStorageFailureUnknown = 7
 	RestObjectExists          = 8
 )
@@ -56,15 +56,21 @@ func (err *restError) Error() (out string) {
 	switch (*err).code {
 
 	case RestResourceBusy:
-		out = fmt.Sprint("Resource is busy. %s", err.msg)
+		out = fmt.Sprintf("Resource is busy. %s", err.msg)
 
 	case RestRequestMalfunction:
-		out = fmt.Sprintf("Malfunction: %s", err.msg)
+		out = fmt.Sprintf("Failure in sending data to storage: %s", err.msg)
 
 	case RestRPM:
-		out = fmt.Sprintf("Failure during processing response from server: %s", err.msg)
+		out = fmt.Sprintf("Failure during processing response from storage: %s", err.msg)
+	case RestResourceDNE:
+		out = fmt.Sprintf("Resource %s do not exists", err.msg)
 	case RestObjectExists:
+
 		out = fmt.Sprintf("Object exists: %s", err.msg)
+
+	case RestStorageFailureUnknown:
+		out = fmt.Sprintf("Storage failes with unknown error: %s", err.msg)
 
 	default:
 		out = fmt.Sprint("Unknown internal Error. %s", err.msg)

--- a/pkg/rest/payload-def.go
+++ b/pkg/rest/payload-def.go
@@ -39,9 +39,9 @@ type ErrorData struct {
 
 // IOStats data on input ourput statistics
 type IOStats struct {
-	Read   string
-	Write  string
-	chksum string
+	Read   string `json:"read"`
+	Write  string `json:"write"`
+	chksum string `json:"chksum"`
 }
 
 // Disk structure returned by server
@@ -72,8 +72,38 @@ type Enabled struct {
 	Enabled bool
 }
 
+///////////////////////////////////////////////////////////////////////////////
+/// Pool
+
+type PoolEnabled struct {
+	Enabled bool `enabled:"enabled"`
+}
+
 // Pool response structure
 type Pool struct {
+	Available  string      `json: "available"`
+	Status     int         `json:"status"`
+	Name       string      `json:"name": "Pool-0"`
+	Scan       int         `json:"scan"`
+	Encryption PoolEnabled `json:"encryption"`
+	Iostats    IOStats     `json:"iostats"`
+	Vdevs      []VDevice   `json:"vdevs"`
+	Health     string      `json:"health"`
+	Operation  string      `json:"operation"`
+	ID         string      `json:"id"`
+	Size       string      `json:"size"`
+}
+
+// GetPoolData response mask
+type GetPoolData struct {
+	Data  Pool
+	Error ErrorT
+}
+
+const GetPoolRCode = 200
+
+// PoolShort element of a pool list
+type PoolShort struct {
 	Name       string
 	Status     int
 	Health     string
@@ -86,7 +116,7 @@ type Pool struct {
 
 // GetPoolsData response mask
 type GetPoolsData struct {
-	Data  []Pool
+	Data  []PoolShort
 	Error ErrorT
 }
 
@@ -98,13 +128,13 @@ const GetPoolsRCode = 200
 
 // Volume response structure
 type Volume struct {
-	Origin               string
-	Reference            string
-	primarycache         string
-	Logbias              string
-	Creation             string
-	Sync                 string
-	Is_clone             bool
+	Origin               string `json:"origin"`
+	Reference            string `json:"referencce"`
+	Primarycache         string `json:"primarycache"`
+	Logbias              string `json:"logbias"`
+	Creation             string `json:"creation"`
+	Sync                 string `json:"sync"`
+	IsClone              bool   `json:"is_clone"`
 	Dedup                string
 	Used                 string
 	Full_name            string
@@ -260,6 +290,7 @@ type SnapshotProperties struct {
 type SnapshotShort struct {
 	Volume     string
 	Name       string
+	Clones     string
 	Properties SnapshotProperties
 }
 
@@ -354,7 +385,7 @@ type DeleteCloneData struct {
 }
 
 // DeleteCloneRCode success status code
-const DeleteCloneRCode = 200
+const DeleteCloneRCode = 204
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Promote cloned volume
@@ -371,6 +402,31 @@ type PromoteCloneData struct {
 
 // PromoteCloneRCode success status code
 const PromoteCloneRCode = 200
+
+///////////////////////////////////////////////////////////////////////////////
+// Get Target
+
+type Target struct {
+	IncomingUsersActive bool     `json:"incoming_users_active"`
+	Name                string   `json:"name"`
+	AllowIP             []string `json:"allow_ip"`
+	OutgoingUser        string   `json:"outgoing_user"`
+	Active              bool     `json:"active"`
+	Conflicted          bool     `json:"conflicted"`
+	DenyIP              []string `json:"deny_ip"`
+}
+
+//GetTargetData data
+type GetTargetData struct {
+	Data  Target
+	Error ErrorT
+}
+
+// GetTargetRCode success status code
+const GetTargetRCode = 200
+
+// GetTargetRCode success status code
+const GetTargetRCodeDoNotExists = 404
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Create Target

--- a/pkg/rest/storage.go
+++ b/pkg/rest/storage.go
@@ -31,12 +31,13 @@ type StorageInterface interface {
 	GetAddress() (string, int)
 
 	// Pools
-	GetPools() ([]Pool, error)
+	GetPool() (*Pool, RestError)
+	GetPools() ([]PoolShort, error)
 
 	// Volumes
 	CreateVolume(vdesc CreateVolumeDescriptor) RestError
 	GetVolume(vname string) (*Volume, RestError)
-	DeleteVolume(vname string) RestError
+	DeleteVolume(vname string, rSnapshots bool) RestError
 	ListVolumes() ([]string, RestError)
 
 	CreateSnapshot(vname string, sname string) RestError
@@ -45,6 +46,7 @@ type StorageInterface interface {
 	ListAllSnapshots(f func(string) bool) ([]SnapshotShort, RestError)
 	ListVolumeSnapshots(string, func(string) bool) ([]SnapshotShort, RestError)
 
+	GetTarget(tname string) (*Target, RestError)
 	CreateTarget(tname string) RestError
 	DeleteTarget(tname string) RestError
 


### PR DESCRIPTION
The documentation states:

`kubectl create secret generic jdss-controller-cfg --from-file=./deploy/cfg/controller.yaml`

however this will mount in the joviandss containers as `controller.yaml`. I updated the mount names so that the docs are correct.

I have also added `version: alpha` to the controller secret to stop this error from occuring:

```
$ k logs -f joviandss-csi-controller-0 csi-attacher
I0310 12:17:31.186978       1 main.go:76] Version: v1.0.1-0-gb7dadac
I0310 12:17:31.187842       1 connection.go:89] Connecting to /var/lib/csi/sockets/pluginproxy/csi.sock
I0310 12:17:31.188059       1 connection.go:116] Still trying, connection is CONNECTING
I0310 12:17:31.188197       1 connection.go:113] Connected
I0310 12:17:31.188205       1 connection.go:242] GRPC call: /csi.v1.Identity/Probe
I0310 12:17:31.188208       1 connection.go:243] GRPC request: {}
I0310 12:17:31.190419       1 connection.go:245] GRPC response: {}
I0310 12:17:31.192355       1 connection.go:246] GRPC error: <nil>
I0310 12:17:31.192364       1 main.go:211] Probe succeeded
I0310 12:17:31.192386       1 connection.go:242] GRPC call: /csi.v1.Identity/GetPluginInfo
I0310 12:17:31.192390       1 connection.go:243] GRPC request: {}
I0310 12:17:31.193856       1 connection.go:245] GRPC response: {}
I0310 12:17:31.194253       1 connection.go:246] GRPC error: rpc error: code = Unavailable desc = Driver is missing version
E0310 12:17:31.194269       1 main.go:125] rpc error: code = Unavailable desc = Driver is missing version
```

I'm making a PR into dev because this probably needs to be successfully built in travis under dev and currently the CSI api's have changed and I believe there is more that needs to be updated in the code to make this compatible with the latest CSI releases. Either this, or versions need to be pinned.

